### PR TITLE
use req.url as a copy instead of mutating directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,13 +50,13 @@ module.exports = class Http extends ReadyResource {
           throw ERR_HTTP_BAD_REQUEST()
         }
         const [url, protocol = 'app', type = 'app'] = req.url.split('+')
-        req.url = url === '/' ? '/index.html' : url
+        const resolvedReq = { __proto__: req, url: url === '/' ? '/index.html' : url }
         if (protocol !== 'app' && protocol !== 'resolve') {
           throw ERR_HTTP_BAD_REQUEST('Unknown protocol')
         }
         const id = isDevtools ? Pear.config.id : xPear.slice(5)
 
-        await this.lookup(id, protocol, type, req, res)
+        await this.lookup(id, protocol, type, resolvedReq, res)
       } catch (err) {
         if (err.code === 'ERR_HTTP_BAD_REQUEST') {
           err.status = err.status || 400

--- a/index.js
+++ b/index.js
@@ -50,7 +50,10 @@ module.exports = class Http extends ReadyResource {
           throw ERR_HTTP_BAD_REQUEST()
         }
         const [url, protocol = 'app', type = 'app'] = req.url.split('+')
-        const resolvedReq = { __proto__: req, url: url === '/' ? '/index.html' : url }
+        const resolvedReq = {
+          __proto__: req,
+          url: url === '/' ? '/index.html' : url
+        }
         if (protocol !== 'app' && protocol !== 'resolve') {
           throw ERR_HTTP_BAD_REQUEST('Unknown protocol')
         }


### PR DESCRIPTION
`bare-http1` is now using req.url as a getter only. This breaks pear-bridge.

Fixes #17 